### PR TITLE
Moved status text behind the realm dropdown

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -52,6 +52,7 @@ body {
 	top: 100px;
 	background: rgba(0, 0, 0, 0.81);
 	height: 50px;
+	z-index: 49;
 }
 
 #status.error {


### PR DESCRIPTION
Moved status/error text behind the realm dropdown so it no longer stops the top few realms from being selected