### PR TITLE
Removed Blood & Unholy Wraith and Skullseye glyphs

### DIFF
--- a/data/professions/inscription.json
+++ b/data/professions/inscription.json
@@ -1934,23 +1934,9 @@
             "name": "Broken Isles World Drops",
             "recipes": [
                 {
-                    "name": "Glyph of the Blood Wraith",
-                    "spellID": 225523,
-                    "source": "Drops from humanoids on the Broken Isles",
-                    "icon": "inv_glyph_minordeathknight",
-                    "iconIndex": 90
-                },
-                {
                     "name": "Glyph of the Chilled Shell",
                     "spellID": 225524,
                     "source": "Drops from water elementals on the Broken Isles",
-                    "icon": "inv_glyph_minordeathknight",
-                    "iconIndex": 90
-                },
-                {
-                    "name": "Glyph of the Unholy Wraith",
-                    "spellID": 225526,
-                    "source": "Drops from ghosts on the Broken Isles",
                     "icon": "inv_glyph_minordeathknight",
                     "iconIndex": 90
                 },
@@ -1979,13 +1965,6 @@
                     "name": "Glyph of the Hook",
                     "spellID": 225541,
                     "source": "Drops from murlocs on the Broken Isles",
-                    "icon": "inv_glyph_minorhunter",
-                    "iconIndex": 89
-                },
-                {
-                    "name": "Glyph of the Skullseye",
-                    "spellID": 225542,
-                    "source": "Drops from undead on the Broken Isles",
                     "icon": "inv_glyph_minorhunter",
                     "iconIndex": 89
                 },


### PR DESCRIPTION
These crafts no longer seem to exist.

Glyph of the Blood Wraith http://www.wowhead.com/spell=225523
Glyph of the Unholy Wraith http://www.wowhead.com/spell=225526
Glyph of the Skullsye http://www.wowhead.com/spell=225542