### PR TITLE
Fix typo with recipe lesser versatility

### DIFF
--- a/data/professions/enchanting.json
+++ b/data/professions/enchanting.json
@@ -2286,7 +2286,7 @@
                     "iconIndex": 0
                 },
                 {
-                    "name": "Lesser Spirit",
+                    "name": "Lesser Versatility",
                     "spellID": 13380,
                     "source": "Drops from level 15-20 mobs",
                     "icon": "spell_holy_greaterheal",


### PR DESCRIPTION
There are currently 2 lesser spirit.
this id is for lesser versatility
Unsure of the values used for mob levels so have left this as is. may need updating